### PR TITLE
make file checkable with cli shasum -c

### DIFF
--- a/src/functionalTest/groovy/org/gradle/crypto/checksum/ChecksumSpec.groovy
+++ b/src/functionalTest/groovy/org/gradle/crypto/checksum/ChecksumSpec.groovy
@@ -111,10 +111,10 @@ class ChecksumSpec extends Specification {
 
         where:
         algo     | sum
-        'MD5'    | '5691b5ad8da499aa156eda19eafa8ca3'
-        'SHA256' | '17dc1d7c1912574351e67069fef64e603d435c7b04197ddb95237cc93ebbe973'
-        'SHA384' | '8c92bd249565af6c1c323450e7f2834a306da1295fa305cfece7c1af1617df6e0213f8b81c8c2765407908f7d2065ced'
-        'SHA512' | '32ae12e4d047303297158cd23a93ba5d7f531b0b8597949a800e0ed57c0d0f6463563f9cb16b99f208bca97cd7471cc4d3ae1ab2b88c026016975dff68c39eb9'
+        'MD5'    | '5691b5ad8da499aa156eda19eafa8ca3  aFile.txt'
+        'SHA256' | '17dc1d7c1912574351e67069fef64e603d435c7b04197ddb95237cc93ebbe973  aFile.txt'
+        'SHA384' | '8c92bd249565af6c1c323450e7f2834a306da1295fa305cfece7c1af1617df6e0213f8b81c8c2765407908f7d2065ced  aFile.txt'
+        'SHA512' | '32ae12e4d047303297158cd23a93ba5d7f531b0b8597949a800e0ed57c0d0f6463563f9cb16b99f208bca97cd7471cc4d3ae1ab2b88c026016975dff68c39eb9  aFile.txt'
     }
 
     def 'supports overlapping output directories'() {

--- a/src/main/java/org/gradle/crypto/checksum/Checksum.java
+++ b/src/main/java/org/gradle/crypto/checksum/Checksum.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.incremental.InputFileDetails;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 public class Checksum extends DefaultTask {
     private FileCollection files;
@@ -109,7 +110,9 @@ public class Checksum extends DefaultTask {
                 HashCode hashCode = null;
                 try {
                     hashCode = Files.asByteSource(input).hash(algorithm.hashFunction);
-                    Files.write(hashCode.toString().getBytes(), sumFile);
+                    String content = String.format("%s  %s", hashCode.toString(), input.getName());
+
+                    Files.write(content.getBytes(), sumFile);
                 } catch (IOException e) {
                     throw new GradleException("Trouble creating checksum", e);
                 }


### PR DESCRIPTION
adds the input filename beside the checksum to make it possible to
check from command line via `sha512sum -c <filename>`